### PR TITLE
Pass severity to log functions

### DIFF
--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1390,11 +1390,11 @@ class fork_daemon
 		{
 			if (isset($this->log_function[$severity]))
 			{
-				return call_user_func($this->log_function[$severity], $message);
+				return call_user_func_array($this->log_function[$severity], array($message, $severity));
 			}
 			elseif (isset($this->log_function[self::LOG_LEVEL_ALL]))
 			{
-				return call_user_func($this->log_function[self::LOG_LEVEL_ALL], $message);
+				return call_user_func_array($this->log_function[self::LOG_LEVEL_ALL], array($message, $severity));
 			}
 		}
 		// Barracuda specific logging class, to keep internal code working


### PR DESCRIPTION
For cases where you're using LOG_LEVEL_ALL, or you're using the same log function for several levels, it would be nice to be able to distinguish between different levels within the logging function.
