### PR TITLE
Add signal number to parent_function_exit callback because multiple sign...

### DIFF
--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -897,7 +897,7 @@ class fork_daemon
 			}
 
 			// make call back to parent exit function if it exists
-			$this->invoke_callback($this->parent_function_exit, $parameters = array(self::$parent_pid), true);
+			$this->invoke_callback($this->parent_function_exit, $parameters = array(self::$parent_pid, $signal_number), true);
 		}
 		else
 		{


### PR DESCRIPTION
...al handlers cannot be defined. This allows the callback to know if it was called from signal_handler_sigint and gives some ability to add custom sigkill logic