### PR TITLE
New feature and two bug fixes

### DIFF
--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1510,15 +1510,6 @@ class fork_daemon
 	}
 
 	/**
-	 * Run signals sent to the process
-	 */
-	public static function dispatch_signals()
-	{
-		// Run signal handlers
-		pcntl_signal_dispatch();
-	}
-
-	/**
 	 * Send a message from the child to the parent
 	 * @param $result
 	 */

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1504,6 +1504,15 @@ class fork_daemon
 	}
 
 	/**
+	 * Run signals sent to the process
+	 */
+	public function dispatch_signals()
+	{
+		// Run signal handlers
+		pcntl_signal_dispatch();
+	}
+
+	/**
 	 * Checks if any changed child sockets are in the bucket.
 	 *
 	 * @param type $bucket The bucket to get results in

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1799,7 +1799,8 @@ class fork_daemon
 			$result = $this->invoke_callback($this->child_function_run[$bucket], $work_unit, false);
 
 			// send the result to the parent
-			self::socket_send($socket_parent, $result);
+			if (is_null($result))
+				self::socket_send($socket_parent, $result);
 
 			// delay the child's exit slightly to avoid race conditions
 			usleep(500);

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1506,7 +1506,7 @@ class fork_daemon
 	/**
 	 * Run signals sent to the process
 	 */
-	public function dispatch_signals()
+	static public function dispatch_signals()
 	{
 		// Run signal handlers
 		pcntl_signal_dispatch();

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -101,7 +101,7 @@ class fork_daemon
 	 * @access protected
 	 * @var string[] $parent_function_prefork
 	 */
-	protected $parent_function_prefork = '';
+	protected $parent_function_prefork = array();
 
 	/**
 	 * Function the parent invokes when a child is spawned

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -187,8 +187,7 @@ class fork_daemon
 
 	/**
 	 * In the child process, stores the socket to get results back to the parent
-	 *
-	 * @var null
+	 * @var socket
 	 */
 	protected $child_socket_to_parent = null;
 

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -99,7 +99,7 @@ class fork_daemon
 	/**
 	 * Function the parent invokes before forking a child
 	 * @access protected
-	 * @var integer $parent_function_prefork
+	 * @var string[] $parent_function_prefork
 	 */
 	protected $parent_function_prefork = '';
 
@@ -530,7 +530,7 @@ class fork_daemon
 	 * @param array names of functions to be called.
 	 * @return bool true if the callback was successfully registered, false if it failed
 	 */
-	public function register_parent_prefork($function_names)
+	public function register_parent_prefork(array $function_names)
 	{
 		$this->parent_function_prefork = $function_names;
 		return true;
@@ -615,7 +615,7 @@ class fork_daemon
 	}
 
 	/**
-	 * Allows the app to set the call back function for when a child process is killed to exceeding its max runtime
+	 * Allows the app to set the call back function for when a child process is killed for exceeding its max runtime
 	 * @access public
 	 * @param string name of function to be called.
 	 * @param int $bucket the bucket to use
@@ -961,7 +961,7 @@ class fork_daemon
 	 * @param int $bucket the bucket to use
 	 * @param bool $sort_queue true to sort the work unit queue
 	 */
-	public function addwork(array $new_work_units, $identifier = '', $bucket = self::DEFAULT_BUCKET, $sort_queue = false)
+	public function addwork($new_work_units, $identifier = '', $bucket = self::DEFAULT_BUCKET, $sort_queue = false)
 	{
 		// ensure bucket is setup before we try to add data to it
 		if (! array_key_exists($bucket, $this->work_units))


### PR DESCRIPTION
This PR fixes two bugs and adds one feature:
- fixed issue where caller could call `register_parent_prefork()` without an array but the code relies on it being an array
- add ability for child to send a message to the parent via `child_send_result_to_parent`
- fixed an issue where a signal interrupting `socket_receive` or `socket_send` would cause the protocol to get out of sync.  without the signal block, sometimes the payload header was being partially consumed resulting in a mixup of the payload header and payload
- small documentation cleanup 