### PR TITLE
Added parameter to kill_child_pid to specify the signal to use for the kill, defaulting to SIGINT

### DIFF
--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1365,11 +1365,20 @@ class fork_daemon
 	 * @return void
 	 * @access public
 	 */
-	public function kill_child_pid($pids, $kill_delay = 30)
+	public function kill_child_pid($pids, $kill_delay = 30, $signal = SIGINT)
 	{
 		if (!is_array($pids))
 		{
 			$pids = array($pids);
+		}
+
+		if ($signal == SIGINT)
+		{
+			$signame = 'sigint';
+		}
+		else
+		{
+			$signame = 'signal ' . $signal;
 		}
 
 		// send int sigs to the children
@@ -1383,7 +1392,7 @@ class fork_daemon
 				continue;
 			}
 
-			$this->safe_kill($pid, SIGINT, 'Asking pid ' . $pid . ' to exit via sigint', self::LOG_LEVEL_INFO);
+			$this->safe_kill($pid, $signal, 'Asking pid ' . $pid . ' to exit via ' . $signame, self::LOG_LEVEL_INFO);
 		}
 
 		// store the requst time

--- a/fork_daemon.php
+++ b/fork_daemon.php
@@ -1362,6 +1362,7 @@ class fork_daemon
 	 *
 	 * @param int $pids       The child pid to kill.
 	 * @param int $kill_delay How many seconds to wait before sending sig kill on stuck processes.
+	 * @param int $signal     The signal to use to alert the child.
 	 * @return void
 	 * @access public
 	 */


### PR DESCRIPTION
I want to use the useful functionality of kill_child_pid but not have it kill the child after the handler is executed, which is what the SIGINT handler does. To achieve this, I want to be able to use SIGHUP as the signal that kill_child_pid uses so I can define a handler for that which will gracefully close the child rather than killing it.

I didn't want to duplicate the functionality of kill_child_pid and wanted the default behaviour to remain unchanged, so this seems the most straightforward way to do it.